### PR TITLE
Use fixed Locale to parse Datetime

### DIFF
--- a/src/main/scala/com/taroid/slideshare4s/SlideShare.scala
+++ b/src/main/scala/com/taroid/slideshare4s/SlideShare.scala
@@ -1,6 +1,7 @@
 package com.taroid.slideshare4s
 
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 /**
  * SlideShareのAPI
@@ -69,7 +70,7 @@ object SlideShare {
     }
     require(sharedSecret.size > 0)
 
-    val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy")
+    val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.US)
     val xmlToSlideshows = new XmlToSlideshowsImpl(dateFormat)
 
     return new SlideShareImpl(apiKey, sharedSecret, scala.xml.XML, xmlToSlideshows)

--- a/src/test/scala/com/taroid/slideshare4s/XmlToSlideshowsImplTest.scala
+++ b/src/test/scala/com/taroid/slideshare4s/XmlToSlideshowsImplTest.scala
@@ -1,10 +1,12 @@
 package com.taroid.slideshare4s
 
-import org.specs2.mutable._
+import java.text.{DateFormat, SimpleDateFormat}
+import java.util.{Locale, Date}
+
 import org.specs2.mock._
-import java.text.{SimpleDateFormat, DateFormat}
+import org.specs2.mutable._
+
 import scala.xml.XML
-import java.util.Date
 
 class XmlToSlideshowsImplTest extends Specification with Mockito {
 
@@ -40,7 +42,7 @@ class XmlToSlideshowsImplTest extends Specification with Mockito {
     }
 
     "引数にスライド情報を渡すとSlideshowのリストを返す" in {
-      val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy")
+      val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.US)
       val slideshows = new XmlToSlideshowsImpl(dateFormat).convert(xml)
 
       slideshows must haveTheSameElementsAs(List(Slideshow(


### PR DESCRIPTION
実行環境の locale (`java.util.Locale#getDefault()`) の値によっては日付のパース時に例外吐くので、ローカルの locale を利用しない様に修正。

Before
```
SlideShare.scala

val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy")
```

```
[info] ! 引数にスライド情報を渡すとSlideshowのリストを返す
[error]     ParseException: Unparseable date: "Thu Jan 01 00:00:00 +0900 2013" (XmlToSlideshowsImpl.scala:35)
[error] com.taroid.slideshare4s.XmlToSlideshowsImpl$$anonfun$convert$1.apply(XmlToSlideshowsImpl.scala:35)
[error] com.taroid.slideshare4s.XmlToSlideshowsImpl$$anonfun$convert$1.apply(XmlToSlideshowsImpl.scala:24)
[error] com.taroid.slideshare4s.XmlToSlideshowsImpl.convert(XmlToSlideshowsImpl.scala:24)
[error] com.taroid.slideshare4s.XmlToSlideshowsImplTest$$anonfun$1$$anonfun$apply$7.apply(XmlToSlideshowsImplTest.scala:46)
[error] com.taroid.slideshare4s.XmlToSlideshowsImplTest$$anonfun$1$$anonfun$apply$7.apply(XmlToSlideshowsImplTest.scala:44)
[info] Total for specification XmlToSlideshowsImplTest
```

After
```
SlideShare.scala

val dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss Z yyyy", Locale.US)
```
```
[info] + 引数にスライド情報を渡すとSlideshowのリストを返す
[info] Total for specification XmlToSlideshowsImplTest
[info] Finished in 25 ms
[info] 3 examples, 0 failure, 0 error
```

